### PR TITLE
Using 'strapi new .' does not create a new folder

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -37,7 +37,7 @@ module.exports = function before(scope, cb) {
   });
 
   // Make changes to the rootPath where the Strapi project will be created.
-  scope.rootPath = path.resolve(process.cwd(), scope.name || '');
+  scope.rootPath = path.resolve(process.cwd(), scope.args[0] || '');
 
   // Ensure we aren't going to inadvertently delete any files.
   try {


### PR DESCRIPTION
before `cd project; strapi new .` creates a new folder names project. 

This will use the `.` directory as as `scope.rootPath`